### PR TITLE
Feature/data downloader

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+qal/data/**/*.tiff filter=lfs diff=lfs merge=lfs -text
+qal/data/**/*.tif filter=lfs diff=lfs merge=lfs -text

--- a/.gitignore
+++ b/.gitignore
@@ -136,6 +136,9 @@ ENV/
 env.bak/
 venv.bak/
 
+# DS Store file from Mac computers
+.DS_Store
+
 # Spyder project settings
 .spyderproject
 .spyproject

--- a/qal/data/_fetchers.py
+++ b/qal/data/_fetchers.py
@@ -1,0 +1,289 @@
+import os
+import hashlib
+import shutil
+import pooch
+from skimage import io
+
+try:
+    from ._registry import registry
+except ImportError:
+    # If your registry is simply in the same folder, do a local import:
+    from _registry import registry
+
+try:
+    from pooch import file_hash
+except ModuleNotFoundError:
+    def file_hash(fname, alg="sha256"):
+        """
+        Calculate the hash of a given file.
+        Useful for checking if a file has changed or been corrupted.
+
+        Parameters
+        ----------
+        fname : str
+            The name of the file.
+        alg : str
+            The type of the hashing algorithm.
+
+        Returns
+        -------
+        hash : str
+            The hash of the file.
+        """
+        if alg not in hashlib.algorithms_available:
+            raise ValueError(f"Algorithm '{alg}' not available in hashlib")
+        hasher = hashlib.new(alg)
+        with open(fname, "rb") as fin:
+            for chunk in iter(lambda: fin.read(65536), b""):
+                hasher.update(chunk)
+        return hasher.hexdigest()
+
+def _create_image_fetcher(branch="main"):
+    """
+    Create a pooch fetcher object that handles downloading/caching data files.
+
+    Parameters
+    ----------
+    branch : str
+        The branch to fetch files from.
+
+    Returns
+    -------
+    pooch.Pooch
+        Configured pooch fetcher.
+    """
+    base_url = f"https://github.com/QUEL-Imaging/q-qal/raw/{branch}/qal/data/"
+    cache_dir = pooch.os_cache("q-qal-data")
+
+    # Create the Pooch fetcher
+    return pooch.create(
+        path=cache_dir,
+        base_url=base_url,
+        registry=registry,
+    )
+
+# Initialize the fetcher
+_image_fetcher = _create_image_fetcher(branch='feature/data-downloader')
+
+def _fetch(filename):
+    """
+    Fetch a file by name from the registry, downloading if necessary.
+
+    Parameters
+    ----------
+    filename : str
+        The name of the file to fetch.
+
+    Returns
+    -------
+    str
+        The local, absolute path to the file.
+
+    Raises
+    ------
+    ValueError:
+        If the filename is not in the registry.
+    """
+    if filename not in registry:
+        raise ValueError(f"'{filename}' is not in the registry.")
+
+    # Use pooch.retrieve to download the file and verify the hash
+    return pooch.retrieve(
+        url=_image_fetcher.get_url(filename),
+        known_hash=f"sha256:{registry[filename]}",
+        path=_image_fetcher.path,
+        fname=filename,
+        progressbar=True,  # Show a progress bar during download
+    )
+
+def get_cache_dir():
+    """
+    Get the cache directory used by pooch.
+
+    Returns
+    -------
+    str
+        Path to the cache directory.
+    """
+    return str(_image_fetcher.path)
+
+
+def download_all():
+    """
+    Download all data files for offline use.
+
+    Raises
+    ------
+    ModuleNotFoundError:
+        If `_image_fetcher` is not initialized.
+    """
+    if _image_fetcher is None:
+        raise ModuleNotFoundError("Pooch fetcher is not initialized.")
+
+    for filename in registry:
+        print(f"Fetching: {filename}")
+        _fetch(filename)
+
+def clear_cache():
+    """
+    Remove all cached data from the pooch cache directory.
+    """
+    cache_dir = _image_fetcher.path
+    if os.path.exists(cache_dir):
+        print(f"Deleting cache at {cache_dir}...")
+        shutil.rmtree(cache_dir)
+        print("Cache cleared.")
+    else:
+        print("No cache directory found to delete.")
+
+
+def _load(filename):
+    """
+    Load an image from the data cache by name.
+
+    Parameters
+    ----------
+    filename : str
+        Filename within the registry to load.
+
+    Returns
+    -------
+    img : ndarray
+        Image read from local cache.
+    """
+    path = _fetch(filename)
+    return io.imread(path)
+
+def cn_sample_1():
+    """Return the cn_sample_1.tiff path as an ndarray."""
+    return _load("concentration_targets/cn_sample_1.tiff")
+
+def cn_sample_2():
+    """Return the cn_sample_2.tiff path as an ndarray."""
+    return _load("concentration_targets/cn_sample_2.tiff")
+
+# --- Concentration samples
+def cn_sample_1():
+    """
+    Return the cn_sample_1.tiff path as an ndarray.
+    """
+    return _load("concentration_targets/cn_sample_1.tiff")
+
+def cn_sample_2():
+    """
+    Return the cn_sample_2.tiff path as an ndarray.
+    """
+    return _load("concentration_targets/cn_sample_2.tiff")
+
+def cn_sample_3():
+    """
+    Return the cn_sample_3.tiff path as an ndarray.
+    """
+    return _load("concentration_targets/cn_sample_3.tiff")
+
+# --- Depth resolution targets
+def dr_sample1():
+    """
+    Return dr_sample1.tiff as an ndarray.
+    """
+    return _load("depth_resolution_targets/dr_sample1.tiff")
+
+def dr_sample2():
+    """
+    Return dr_sample2.tiff as an ndarray.
+    """
+    return _load("depth_resolution_targets/dr_sample2.tiff")
+
+# --- Depth targets
+def depth_sample_1():
+    """
+    Return depth_sample_1.tiff as an ndarray.
+    """
+    return _load("depth_targets/depth_sample_1.tiff")
+
+# --- Resolution targets
+def res_sample_1():
+    """
+    Return res_sample_1.tiff as an ndarray.
+    """
+    return _load("resolution_targets/res_sample_1.tiff")
+
+def resolution_target_cropped():
+    """
+    Return resolution_target_cropped.tiff as an ndarray.
+    """
+    return _load("resolution_targets/resolution_target_cropped.tiff")
+
+# --- RUD targets, example_1
+def rud_image1_example_1():
+    """
+    Return rud_image1.tiff from example_1 as an ndarray.
+    """
+    return _load("rud_targets/example_1/rud_image1.tiff")
+
+def rud_image2_example_1():
+    """
+    Return rud_image2.tiff from example_1 as an ndarray.
+    """
+    return _load("rud_targets/example_1/rud_image2.tiff")
+
+def rud_image3_example_1():
+    """
+    Return rud_image3.tiff from example_1 as an ndarray.
+    """
+    return _load("rud_targets/example_1/rud_image3.tiff")
+
+def rud_image4_example_1():
+    """
+    Return rud_image4.tiff from example_1 as an ndarray.
+    """
+    return _load("rud_targets/example_1/rud_image4.tiff")
+
+# --- RUD targets, example_2
+def rud_image1_example_2():
+    """
+    Return rud_image1.tiff from example_2 as an ndarray.
+    """
+    return _load("rud_targets/example_2/rud_image1.tiff")
+
+def rud_image2_example_2():
+    """
+    Return rud_image2.tiff from example_2 as an ndarray.
+    """
+    return _load("rud_targets/example_2/rud_image2.tiff")
+
+def rud_image3_example_2():
+    """
+    Return rud_image3.tiff from example_2 as an ndarray.
+    """
+    return _load("rud_targets/example_2/rud_image3.tiff")
+
+def rud_image4_example_2():
+    """
+    Return rud_image4.tiff from example_2 as an ndarray.
+    """
+    return _load("rud_targets/example_2/rud_image4.tiff")
+
+def rud_image5_example_2():
+    """
+    Return rud_image5.tiff from example_2 as an ndarray.
+    """
+    return _load("rud_targets/example_2/rud_image5.tiff")
+
+# --- RUD targets, example_3
+def rud_center_fov_example_3():
+    """
+    Return rud_center_fov.tiff from example_3 as an ndarray.
+    """
+    return _load("rud_targets/example_3/rud_center_fov.tiff")
+
+# --- Lung test
+def lung_test_image():
+    """
+    Return lung_test_image.tiff as an ndarray.
+    """
+    return _load("lung_test_image/lung_test_image.tiff")
+
+#
+# End of _fetchers.py
+#

--- a/qal/data/_registry.py
+++ b/qal/data/_registry.py
@@ -1,0 +1,44 @@
+# Registry of data files with their SHA256 hashes
+# To generate the SHA256 hash, use the command:
+# openssl sha256 filename
+
+registry = {
+    # Concentration Targets
+    "concentration_targets/cn_sample_2.tiff": "a4c37bd36042370567297a6802a623586dc86405f11b14e32c15232849aa06be",
+    "concentration_targets/cn_sample_3.tiff": "aac12c12735f2de5563ab5177361502d2f91386b542dfea949163601392fc54a",
+    "concentration_targets/cn_sample_1.tiff": "a78b4ea0cbf2c6f4badb65e4054a71a636b7f16adda46f3460d63d8a0479b8d4",
+
+    # Depth Targets
+    "depth_targets/depth_sample_1.tiff": "da8a4e6d9f4d7e13048462b06a2efb0f5da10ea4d4d36be2ee07cd3b73c8dbd1",
+
+    # Resolution Targets
+    "resolution_targets/resolution_target_cropped.tiff": "6eecae1044587f2a2598ea97b017cab7c20935fee0d150068dd508523c01e581",
+    "resolution_targets/res_sample_1.tiff": "a0f967202b36ebe732058fb6ab23b952773bb025a3e958752cc232c7a54d8b2d",
+    "depth_resolution_targets/dr_sample2.tiff": "08ff21d678db1b0f29a3ed09fe4e3062d20a6541d32dccfb737e748aa586f49c",
+
+    # Depth Resolution Targets
+    "depth_resolution_targets/dr_sample1.tiff": "58790cc0f3b17e008260337b3ae24457f61fd41d77baaae16570516147439990",
+
+    # Lung Test Image
+    "lung_test_image/lung_test_image.tiff": "fb8bc5a98428cf0acb19693b241805f07c4cd888186820f60fb485d686b3a0fe",
+
+    # Lung Reference Source
+    "lung_reference_source/Phantom image.tiff": "26ec41433735675274476a065792c99abdd34ddb58c6968a08077575b7fee5b0",
+    "lung_reference_source/Inclusions image.tiff": "23c2fee447d5cde3ea965b324fd9afb6be4b68c138fba1af4afb65402f84a458",
+
+    # RUD Targets - Example 1
+    "rud_targets/example_1/rud_image1.tiff": "4594a33578cca3d8b86dc6bc0930acbaeb4d74ea5aad8235664d5ad2ad5ec457",
+    "rud_targets/example_1/rud_image3.tiff": "e47930c56b02ffa2e581ae7a8f331c175e9cee62adde0bb153b4efa3ec912f12",
+    "rud_targets/example_1/rud_image2.tiff": "34d8405754e43109901cf9642015f72da340460128d7053066f8beb561009213",
+    "rud_targets/example_1/rud_image4.tiff": "84ddaa6e4ece30d0f228c2fc62b30fd4464c11c2ba6d358537c6254e76a090b4",
+
+    # RUD Targets - Example 2
+    "rud_targets/example_2/rud_image1.tiff": "382728a8810f4e50e29de53263a1334d9b323e784957703a7be759d18345193e",
+    "rud_targets/example_2/rud_image3.tiff": "7fd4ceb9ef9620264593d6937e08f1d2b1db448ae9f23ae5db818bc2d3d1833c",
+    "rud_targets/example_2/rud_image2.tiff": "308da7d7d76cadc00063f2bb20fda61e1b9f9e0589ae7523f518ecc58c2b9ac9",
+    "rud_targets/example_2/rud_image5.tiff": "f0ef2923a4829ef08b46d904b6a6dea272069cd693595ef41f58663fc3b5c174",
+    "rud_targets/example_2/rud_image4.tiff": "52a7ecae992d4ce9ce932d22527f422f029ca955935fca7ce8e10ccaff1ced1d",
+
+    # RUD Targets - Example 3
+    "rud_targets/example_3/rud_center_fov.tiff": "984cc3cab573c06c1ab3c0b4b2db5e14038cab18c3feacdf98598ca9370f7b19",
+}

--- a/qal/data/concentration_targets/cn_sample_1.tiff
+++ b/qal/data/concentration_targets/cn_sample_1.tiff
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a78b4ea0cbf2c6f4badb65e4054a71a636b7f16adda46f3460d63d8a0479b8d4
+size 23388858

--- a/qal/data/concentration_targets/cn_sample_2.tiff
+++ b/qal/data/concentration_targets/cn_sample_2.tiff
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a4c37bd36042370567297a6802a623586dc86405f11b14e32c15232849aa06be
+size 23388940

--- a/qal/data/concentration_targets/cn_sample_3.tiff
+++ b/qal/data/concentration_targets/cn_sample_3.tiff
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:aac12c12735f2de5563ab5177361502d2f91386b542dfea949163601392fc54a
+size 23388940

--- a/qal/data/depth_resolution_targets/dr_sample1.tiff
+++ b/qal/data/depth_resolution_targets/dr_sample1.tiff
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:58790cc0f3b17e008260337b3ae24457f61fd41d77baaae16570516147439990
+size 23388940

--- a/qal/data/depth_resolution_targets/dr_sample2.tiff
+++ b/qal/data/depth_resolution_targets/dr_sample2.tiff
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:08ff21d678db1b0f29a3ed09fe4e3062d20a6541d32dccfb737e748aa586f49c
+size 23388915

--- a/qal/data/depth_targets/depth_sample_1.tiff
+++ b/qal/data/depth_targets/depth_sample_1.tiff
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:da8a4e6d9f4d7e13048462b06a2efb0f5da10ea4d4d36be2ee07cd3b73c8dbd1
+size 3968065

--- a/qal/data/lung_reference_source/Inclusions image.tiff
+++ b/qal/data/lung_reference_source/Inclusions image.tiff
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:23c2fee447d5cde3ea965b324fd9afb6be4b68c138fba1af4afb65402f84a458
+size 23388928

--- a/qal/data/lung_reference_source/Phantom image.tiff
+++ b/qal/data/lung_reference_source/Phantom image.tiff
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:26ec41433735675274476a065792c99abdd34ddb58c6968a08077575b7fee5b0
+size 23388928

--- a/qal/data/lung_test_image/lung_test_image.tiff
+++ b/qal/data/lung_test_image/lung_test_image.tiff
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fb8bc5a98428cf0acb19693b241805f07c4cd888186820f60fb485d686b3a0fe
+size 23388992

--- a/qal/data/resolution_targets/res_sample_1.tiff
+++ b/qal/data/resolution_targets/res_sample_1.tiff
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a0f967202b36ebe732058fb6ab23b952773bb025a3e958752cc232c7a54d8b2d
+size 2506672

--- a/qal/data/resolution_targets/resolution_target_cropped.tiff
+++ b/qal/data/resolution_targets/resolution_target_cropped.tiff
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6eecae1044587f2a2598ea97b017cab7c20935fee0d150068dd508523c01e581
+size 134952

--- a/qal/data/rud_targets/example_1/rud_image1.tiff
+++ b/qal/data/rud_targets/example_1/rud_image1.tiff
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4594a33578cca3d8b86dc6bc0930acbaeb4d74ea5aad8235664d5ad2ad5ec457
+size 23388928

--- a/qal/data/rud_targets/example_1/rud_image2.tiff
+++ b/qal/data/rud_targets/example_1/rud_image2.tiff
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:34d8405754e43109901cf9642015f72da340460128d7053066f8beb561009213
+size 23388928

--- a/qal/data/rud_targets/example_1/rud_image3.tiff
+++ b/qal/data/rud_targets/example_1/rud_image3.tiff
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e47930c56b02ffa2e581ae7a8f331c175e9cee62adde0bb153b4efa3ec912f12
+size 23388928

--- a/qal/data/rud_targets/example_1/rud_image4.tiff
+++ b/qal/data/rud_targets/example_1/rud_image4.tiff
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:84ddaa6e4ece30d0f228c2fc62b30fd4464c11c2ba6d358537c6254e76a090b4
+size 23388928

--- a/qal/data/rud_targets/example_2/rud_image1.tiff
+++ b/qal/data/rud_targets/example_2/rud_image1.tiff
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:382728a8810f4e50e29de53263a1334d9b323e784957703a7be759d18345193e
+size 7215256

--- a/qal/data/rud_targets/example_2/rud_image2.tiff
+++ b/qal/data/rud_targets/example_2/rud_image2.tiff
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:308da7d7d76cadc00063f2bb20fda61e1b9f9e0589ae7523f518ecc58c2b9ac9
+size 7215256

--- a/qal/data/rud_targets/example_2/rud_image3.tiff
+++ b/qal/data/rud_targets/example_2/rud_image3.tiff
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7fd4ceb9ef9620264593d6937e08f1d2b1db448ae9f23ae5db818bc2d3d1833c
+size 7215256

--- a/qal/data/rud_targets/example_2/rud_image4.tiff
+++ b/qal/data/rud_targets/example_2/rud_image4.tiff
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:52a7ecae992d4ce9ce932d22527f422f029ca955935fca7ce8e10ccaff1ced1d
+size 7215256

--- a/qal/data/rud_targets/example_2/rud_image5.tiff
+++ b/qal/data/rud_targets/example_2/rud_image5.tiff
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f0ef2923a4829ef08b46d904b6a6dea272069cd693595ef41f58663fc3b5c174
+size 7215256

--- a/qal/data/rud_targets/example_3/rud_center_fov.tiff
+++ b/qal/data/rud_targets/example_3/rud_center_fov.tiff
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:984cc3cab573c06c1ab3c0b4b2db5e14038cab18c3feacdf98598ca9370f7b19
+size 23388928


### PR DESCRIPTION
This pull request adds example data images, a registry for the data, and fetcher functions to pull images. Images that are downloaded using the fetcher function will download all or select images into the caches folder in the operating system being used.

The code below demonstrates how a single image from the examples can be used. Images are outlined as individual functions. Each image function will first check to see if the image is downloaded, then return an ndarray called using `io.imread(image)`. If an image has been downloaded, the function will skip the downloading step.

```
from _fetchers import cn_sample_1
import matplotlib.pyplot as plt

plt.imshow(cn_sample_1())
plt.show()
```

All images available in the example dataset can be downloaded using the download_all function.
```
from _fetchers import download_all

download_all()
```

All images can be deleted using the clear_cache function.
```
from _fetchers import clear_cache

clear_cache
```

Downloaded images are stored using the same folder structure as seen in the repository. Folders can be referenced using the following approach.

```
from _fetchers import get_cache_dir
import glob
import os

cache_dir = get_cache_dir()

print(cache_dir)

target_type = "rud_targets/example_1"

image_files = glob.glob(os.path.join(cache_dir, target_type, "**", "*.tiff"), recursive=True)

print(image_files)
```