### PR TITLE
Bugfix for depth resolution analysis channel selection and image auto-rotation

### DIFF
--- a/doc/dr_README.md
+++ b/doc/dr_README.md
@@ -85,7 +85,9 @@ Full execution of this code will generate the following plots:
 
 | Input  | Description |
 | ------------- | ------------- |
-| Depths  | Chosen depths for which to evaluate intensity spread |
+| rotate_image_90 | (True or False) Parameter to rotate image 90 degrees so that channels run horizontal, default = False |
+| channel_distance_from_top | Percent (in fraction format [0 to 1] ) from the top that indicates the channel position, default = 0.5 |
+| depths  | Chosen depths for which to evaluate intensity spread |
 
 Optionally, to change the dimensions of the phantom, the following code should be changed (also shown above in the example code):
 
@@ -99,7 +101,7 @@ The intensity, spread, and FWHM profiles are then obtained:
 
 ## Intensity profiles:
 
-The intensity through the center of the channel of the phantom is found and smoothed. This is plotted against the x-dimension units (mm) of the phantom.
+The intensity through the channel (indicated by channel_distance_from_top, default = 0.5 for the center row) of the phantom is found and smoothed. This is plotted against the x-dimension units (mm) of the phantom.
 
 The intensity profile is also cropped to the descending portion of the phantom, which is mapped to the varying depth of the phantom. This cropped intensity is normalized and fit to an exponential function and is plotted.
 
@@ -214,12 +216,15 @@ from qal.data import dr_sample3
 from qal import PhantomCropper, DepthAnalyzer, DepthDataPlotter
 from skimage import io
 import matplotlib.pyplot as plt
-
-# Custom image
+# Load example image 3 or custom image
+# im3 = io.imread('***replace-with-path-to-your-image***')
 im3 = dr_sample3()
 
 # Directories to save plots to if desired (change from None)
 save_dir3 = None
+
+# Rotate the phantom image 90 degrees if needed to ensure channels are horizontal
+rotate_image_90 = False
 
 # Crop the image
 cropper = PhantomCropper()
@@ -233,20 +238,22 @@ left = cropper.borders["left"]
 right = cropper.borders["right"]
 
 cropped = img[int(top):int(bottom), int(left):int(right)]
-if (bottom - top) > (right - left):     # Check whether phantom orientation is vertical
-    cropped = cropped.T
-plt.imshow(np.rot90(cropped, 2), extent=[0, 50, 0 , 35], cmap='inferno') # change extent to x and y dimensions (mm)
+if rotate_image_90 == True:
+        cropped = cropped.T
+
+plt.imshow(cropped, extent=[0, 50, 0 , 35], cmap='inferno') # change extent to x and y dimensions (mm)
 plt.xlabel('X-axis (mm)', fontsize=16, fontweight='bold')
 plt.ylabel('Y-axis (mm)', fontsize=16, fontweight='bold')
+plt.title('Cropped Fluorescence Image', fontsize=16)
 plt.show()
 
 
-# Set dimensions and analyze CROPPER for relevant information
+# # Set dimensions and analyze CROPPER for relevant information
 analyzer = DepthAnalyzer(cropper)
 analyzer.depth_start_end = [1.3, 7.3] # z-depths (mm)
 analyzer.descent_start_end = [6, 44] # x-positions (mm)
 analyzer.phantom_dimensions = [35, 50] # y, x dimensions
-analyzer.get_profiles(depths=np.linspace(1.3, 7.3, 10)) # same as depth_start_end, 10 points in between
+analyzer.get_profiles(rotate_image_90, channel_distance_from_top = 0.5, depths=np.linspace(1.3, 7.3, 10)) # channel_distance_from_top = percent (as fraction) from the top where the channel is (0.5 for 50%), depths = same as depth_start_end, 10 points in between
 
 # Plot data in ANALYZER
 depth_data_plotter = DepthDataPlotter(analyzer.outputs)

--- a/qal/examples/depth_resolution_example.py
+++ b/qal/examples/depth_resolution_example.py
@@ -1,3 +1,12 @@
+import platform
+import matplotlib
+
+if platform.system() == "Darwin":
+    try:
+        matplotlib.use("TkAgg", force=True)
+    except Exception:
+        pass
+
 import numpy as np
 from qal.data import dr_sample1, dr_sample2, dr_sample3
 from qal import PhantomCropper, DepthAnalyzer, DepthDataPlotter
@@ -77,11 +86,13 @@ def main():
     if rotate_image_90 == True:
             cropped = cropped.T
 
-    plt.imshow(cropped, extent=[0, 50, 0 , 35], cmap='inferno') # change extent to x and y dimensions (mm)
-    plt.xlabel('X-axis (mm)', fontsize=16, fontweight='bold')
-    plt.ylabel('Y-axis (mm)', fontsize=16, fontweight='bold')
-    plt.title('Cropped Fluorescence Image', fontsize=16)
-    plt.show()
+    fig, ax = plt.subplots()
+    ax.imshow(cropped, extent=[0, 50, 0 , 35], cmap='inferno') # change extent to x and y dimensions (mm)
+    ax.set_xlabel('X-axis (mm)', fontsize=16, fontweight='bold')
+    ax.set_ylabel('Y-axis (mm)', fontsize=16, fontweight='bold')
+    ax.set_title('Cropped Fluorescence Image', fontsize=16)
+    plt.show(block=False)
+    plt.pause(0.01)
 
 
     # Set dimensions and analyze CROPPER for relevant information

--- a/qal/examples/depth_resolution_example.py
+++ b/qal/examples/depth_resolution_example.py
@@ -59,6 +59,9 @@ def main():
     # Directories to save plots to if desired (change from None)
     save_dir3 = None
 
+    # Rotate the phantom image 90 degrees if needed to ensure channels are horizontal
+    rotate_image_90 = False
+
     # Crop the image
     cropper = PhantomCropper()
     cropper.crop_image(im3)
@@ -71,22 +74,22 @@ def main():
     right = cropper.borders["right"]
 
     cropped = img[int(top):int(bottom), int(left):int(right)]
-    if (bottom - top) > (right - left):     # Check whether phantom orientation is vertical
-        cropped = cropped.T
+    if rotate_image_90 == True:
+            cropped = cropped.T
 
-    plt.imshow(np.rot90(cropped, 2), extent=[0, 50, 0 , 35], cmap='inferno') # change extent to x and y dimensions (mm)
+    plt.imshow(cropped, extent=[0, 50, 0 , 35], cmap='inferno') # change extent to x and y dimensions (mm)
     plt.xlabel('X-axis (mm)', fontsize=16, fontweight='bold')
     plt.ylabel('Y-axis (mm)', fontsize=16, fontweight='bold')
     plt.title('Cropped Fluorescence Image', fontsize=16)
     plt.show()
 
 
-    # Set dimensions and analyze CROPPER for relevant information
+    # # Set dimensions and analyze CROPPER for relevant information
     analyzer = DepthAnalyzer(cropper)
     analyzer.depth_start_end = [1.3, 7.3] # z-depths (mm)
     analyzer.descent_start_end = [6, 44] # x-positions (mm)
     analyzer.phantom_dimensions = [35, 50] # y, x dimensions
-    analyzer.get_profiles(depths=np.linspace(1.3, 7.3, 10)) # same as depth_start_end, 10 points in between
+    analyzer.get_profiles(rotate_image_90, channel_distance_from_top = 0.5, depths=np.linspace(1.3, 7.3, 10)) # channel_distance_from_top = percent (as fraction) from the top where the channel is (0.5 for 50%), depths = same as depth_start_end, 10 points in between
 
     # Plot data in ANALYZER
     depth_data_plotter = DepthDataPlotter(analyzer.outputs)

--- a/qal/examples/depth_resolution_example.py
+++ b/qal/examples/depth_resolution_example.py
@@ -84,7 +84,7 @@ def main():
     plt.show()
 
 
-    # # Set dimensions and analyze CROPPER for relevant information
+    # Set dimensions and analyze CROPPER for relevant information
     analyzer = DepthAnalyzer(cropper)
     analyzer.depth_start_end = [1.3, 7.3] # z-depths (mm)
     analyzer.descent_start_end = [6, 44] # x-positions (mm)

--- a/qal/rta/image_analyzer/depth_resolution_analyzer.py
+++ b/qal/rta/image_analyzer/depth_resolution_analyzer.py
@@ -22,11 +22,12 @@ class DepthAnalyzer:
             "Polynomial order": 3
         }
 
-    def get_profiles(self, depths=None):
+    def get_profiles(self, rotate_image_90 = False, channel_distance_from_top = 0.5, depths=None):
         """
         Analyze the image from CROPPER to produce an intensity profile and spread profile.
-
-        :param depths:              Depths for which to evaluate intensity spread
+        :param rotate_image_90                 True or False, if the image needs to be rotated so that channels are horizontal
+        :param channel_distance_from_top       Percent (in fraction format [0 to 1] ) from the top that indicates the channel position, default = 0.5
+        :param depths:                         Depths for which to evaluate intensity spread
         :return:
         """
 
@@ -49,7 +50,8 @@ class DepthAnalyzer:
 
         # Obtain region of image to be analyzed
         cropped = img[int(top):int(bottom), int(left):int(right)]
-        if (bottom - top) > (right - left):     # Check whether phantom orientation is vertical
+        # if (bottom - top) > (right - left):     # Check whether phantom orientation is vertical
+        if rotate_image_90 == True:
             cropped = cropped.T
 
         # Check if phantom is oriented such that it has higher intensity on the right. If so, flip
@@ -64,8 +66,7 @@ class DepthAnalyzer:
         )
 
         # Get the intensity profile and peak intensity along the channel (The intensity profile is the row at the center of the image)
-        channel_row_index = round(cropped.shape[0]*0.5)
-        print(channel_row_index)
+        channel_row_index = round(cropped.shape[0]*channel_distance_from_top)
         intensity_profile = cropped[channel_row_index, :]
         peak_max = np.max(intensity_profile)
 

--- a/qal/rta/image_analyzer/depth_resolution_analyzer.py
+++ b/qal/rta/image_analyzer/depth_resolution_analyzer.py
@@ -63,10 +63,10 @@ class DepthAnalyzer:
                     int(0.9 * cropped.shape[1]):int(0.95 * cropped.shape[1])]
         )
 
-        # Get the intensity profile and peak intensity along the channel
-        average_col_intensity = np.mean(cropped, axis=1)
-        max_row_index = np.argmax(average_col_intensity)
-        intensity_profile = cropped[max_row_index, :]
+        # Get the intensity profile and peak intensity along the channel (The intensity profile is the row at the center of the image)
+        channel_row_index = round(cropped.shape[0]*0.5)
+        print(channel_row_index)
+        intensity_profile = cropped[channel_row_index, :]
         peak_max = np.max(intensity_profile)
 
         # Smooth the intensity profile
@@ -80,7 +80,7 @@ class DepthAnalyzer:
         descent_depth = np.linspace(self.depth_start_end[0], self.depth_start_end[1], len(descent_distance))
         descent_intensities = intensity_profile[mask].astype(np.float64)
         descent_intensities_smoothed = intensity_profile_smoothed[mask]
-        vert_distance = ((np.arange(cropped.shape[0]) - max_row_index) / cropped.shape[0]) * self.phantom_dimensions[0]
+        vert_distance = ((np.arange(cropped.shape[0]) - channel_row_index) / cropped.shape[0]) * self.phantom_dimensions[0] 
 
         # Store some outputs
         self.outputs["Depths"] = depths

--- a/qal/rta/image_analyzer/depth_resolution_analyzer.py
+++ b/qal/rta/image_analyzer/depth_resolution_analyzer.py
@@ -163,7 +163,10 @@ class DepthAnalyzer:
         # Optionally smooth the input data, the calculate AUC
         if smooth:
             curve = self.smooth_data(curve)
-        auc = np.trapz(curve)
+        integrate = getattr(np, "trapezoid", None)
+        if integrate is None:
+            integrate = getattr(np, "trapz")
+        auc = integrate(curve)
 
         return auc
 

--- a/qal/rta/roi_extraction/crop_depth_phantom.py
+++ b/qal/rta/roi_extraction/crop_depth_phantom.py
@@ -25,13 +25,17 @@ class PhantomCropper:
         fig, ax = plt.subplots(figsize=[11, 7.5])
         ax.imshow(self.log_img, cmap='gray')
         ax.set_axis_off()
+        fig.canvas.draw_idle()
+        plt.show(block=False)
+        self._focus_figure_window(fig)
+        plt.pause(0.15)
         use_word = ['top', 'bottom', 'left', 'right']
         pts = []
         self.borders = {}
         for i in range(4):
             ax.set_title(f"Select a point on the {use_word[i]} edge of the phantom")
-            plt.draw()
-            pt = plt.ginput(timeout=-1)[0]
+            fig.canvas.draw_idle()
+            pt = fig.ginput(1, timeout=-1)[0]
             pts.append(pt)
             if i < 2:
                 ax.plot([0, x_ext - 1], [pt[1], pt[1]], color='r')
@@ -61,3 +65,32 @@ class PhantomCropper:
         c = uint16_max / np.log(1 + np.max(image))
         log_image = c * (np.log(image + 1.0))
         self.log_img = np.array(log_image, dtype=np.uint16)
+
+    @staticmethod
+    def _focus_figure_window(fig):
+        """
+        Best-effort figure focus so the first click is captured on GUI backends.
+        """
+        manager = getattr(fig.canvas, 'manager', None)
+        window = getattr(manager, 'window', None)
+
+        for obj, method_name in (
+            (manager, 'show'),
+            (window, 'show'),
+            (window, 'raise_'),
+            (window, 'activateWindow'),
+            (window, 'setFocus'),
+            (window, 'focus_force'),
+            (window, 'focus_set'),
+            (window, 'makeKeyAndOrderFront_'),
+            (window, 'orderFrontRegardless'),
+        ):
+            if obj is None:
+                continue
+            method = getattr(obj, method_name, None)
+            if method is None:
+                continue
+            try:
+                method()
+            except Exception:
+                pass


### PR DESCRIPTION
Previously, the intensity profile was determined by the brightest row as the channel (#39 ). This provides inaccurate analysis for a control image (where the channel is not the brightest) or for a multiple channel phantom (multiple 'brightest' channels). The following code updates the analysis and example code (Example 3) so that the intensity profile is now determined by the channel distance (in fraction/percent ex: 0.5 = center) from the top of the phantom, assuming the channels are horizontal. 

Additionally, the previous code would detect the longer edge of the phantom and force that as the x-axis through a rotation, but some phantoms may be longer in the y-dimension than x-dimension. This updates the examples and analysis code so that the user can define if a 90 degree rotation is needed so that the channels are horizontal. 

The example images and outputs remain the same as before, but the code is now more functional for custom images.

Example 3 selected outputs with rotate_image_90 = False and channel_distance_from_top = 0.5:
<img width="603" height="447" alt="Screenshot 2026-01-06 at 8 49 04 AM" src="https://github.com/user-attachments/assets/d1bbafb8-3bf6-4637-a944-013e89529193" />
<img width="787" height="585" alt="Screenshot 2026-01-06 at 8 49 22 AM" src="https://github.com/user-attachments/assets/5ceceedd-6549-42c9-9078-65488c9a145c" />
<img width="792" height="591" alt="Screenshot 2026-01-06 at 8 49 33 AM" src="https://github.com/user-attachments/assets/04b60d18-c613-4941-b3e1-1524bdf3b57d" />

Example 3 selected outputs with rotate_image_90 = False and channel_distance_from_top = **0.33**:
<img width="797" height="598" alt="Screenshot 2026-01-06 at 8 50 35 AM" src="https://github.com/user-attachments/assets/9ca37149-c0e7-4836-a8c3-8c66d6856f93" />

Example 3 selected outputs with rotate_image_90 = **True** and channel_distance_from_top = 0.5:
<img width="626" height="467" alt="Screenshot 2026-01-06 at 8 51 44 AM" src="https://github.com/user-attachments/assets/9fa2c18e-1336-4206-ba68-7a0ef256239b" />
<img width="795" height="598" alt="Screenshot 2026-01-06 at 8 51 55 AM" src="https://github.com/user-attachments/assets/b9d7fb23-83c8-49aa-bd2a-4428ca7984e1" />
<img width="798" height="596" alt="Screenshot 2026-01-06 at 8 52 11 AM" src="https://github.com/user-attachments/assets/cba9493a-ee86-4df4-9967-a985994e0954" />


